### PR TITLE
Fixed improper NXDOMAIN usage

### DIFF
--- a/recursor/filter-aaaa.lua
+++ b/recursor/filter-aaaa.lua
@@ -8,7 +8,6 @@
 -- PowerDNS recursor 3.4+ is required
 
 function postresolve(remoteip, domain, qtype, records, rcode)
-  local rcode_new = rcode
   local records_new = {}
 
   for i, record in ipairs(records) do
@@ -17,10 +16,6 @@ function postresolve(remoteip, domain, qtype, records, rcode)
     end
   end
 
-  if #records_new == 0 then
-    rcode_new = pdns.NXDOMAIN
-  end
-
-  return rcode_new, records_new
+  return rcode, records_new
 end
 


### PR DESCRIPTION
The "if #records_new == 0 then" block would improperly return NXDOMAIN
if the record type queried was AAAA but the domain also had A records.

Removed that section of code. If the domain truly is NXDOMAIN then that
status gets passed down from the original return code (rcode) and
records_new is null. Otherwise simply filter out AAAA records.
